### PR TITLE
Hotfix/hirohiro/fix deploy package name

### DIFF
--- a/Assets/OpenApiCodeGen.meta
+++ b/Assets/OpenApiCodeGen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c038d342c58048fea8dccc425d91d6f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 92f8825849c0f42e4b66f7750c9e6ecc
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Packages/OpenApiCodeGen/CHANGELOG.md
+++ b/Packages/OpenApiCodeGen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## unreleased
 
+## [0.3.1]
+
+### Fixed
+
+- change package name in uxml
+
 ## [0.3.0]
 
 ### Feature

--- a/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/MenuWindow.uxml
+++ b/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/MenuWindow.uxml
@@ -1,5 +1,5 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Packages/com.rebeat.openapicodegen/Editor/UI/MainMenu/MenuWindow.uss?fileID=7433441132597879392&amp;guid=388ca6004f36749a6b4b09cb6c501c03&amp;type=3#MenuWindow" />
+    <Style src="project://database/Packages/jp.rebeat.openapicodegen/Editor/UI/MainMenu/MenuWindow.uss?fileID=7433441132597879392&amp;guid=388ca6004f36749a6b4b09cb6c501c03&amp;type=3#MenuWindow" />
     <ui:ScrollView>
         <ui:Label tabindex="-1" text="OpenAPI Code Generator" display-tooltip-when-elided="true" name="Title" style="-unity-font-style: bold; font-size: 28px;" />
         <ui:TextField picking-mode="Ignore" label="document file path/url" name="DocumentFilePath" binding-path="m_DocumentFilePath" style="white-space: nowrap; text-overflow: ellipsis;" />

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/SettingMenu.uxml
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/SettingMenu.uxml
@@ -1,5 +1,5 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Packages/com.rebeat.openapicodegen/Editor/UI/SettingMenu/SettingMenu.uss?fileID=7433441132597879392&amp;guid=85d61e68e42234629a04d6023ac5024b&amp;type=3#SettingMenu" />
+    <Style src="project://database/Packages/jp.rebeat.openapicodegen/Editor/UI/SettingMenu/SettingMenu.uss?fileID=7433441132597879392&amp;guid=85d61e68e42234629a04d6023ac5024b&amp;type=3#SettingMenu" />
     <ui:ScrollView class="setting-menu-scroll">
         <ui:Label tabindex="-1" text="Setting Menu" display-tooltip-when-elided="true" style="font-size: 30px; -unity-font-style: bold;" />
         <ui:Foldout text="User Settings" name="UserSettingsFoldout" class="setting-section" style="font-size: 14px;">

--- a/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/SetupMenu.uxml
+++ b/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/SetupMenu.uxml
@@ -1,5 +1,5 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Packages/com.rebeat.openapicodegen/Editor/UI/SetupMenu/SetupMenu.uss?fileID=7433441132597879392&amp;guid=95ad4dafff53c44029241f28a46bf7b4&amp;type=3#SetupMenu" />
+    <Style src="project://database/Packages/jp.rebeat.openapicodegen/Editor/UI/SetupMenu/SetupMenu.uss?fileID=7433441132597879392&amp;guid=95ad4dafff53c44029241f28a46bf7b4&amp;type=3#SetupMenu" />
     <ui:Label text="Setup OpenAPI Code Generator" style="-unity-font-style: bold; font-size: 30px;" />
     <ui:GroupBox name="SetupGroup" style="margin-top: 24px;">
         <ui:Label tabindex="-1" text="1. Choose Generate Provider" display-tooltip-when-elided="true" style="-unity-font-style: bold; font-size: 16px; margin-bottom: 16px;" />

--- a/Packages/OpenApiCodeGen/package.json
+++ b/Packages/OpenApiCodeGen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp.rebeat.openapicodegen",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "displayName": "OpenApiCodeGen",
   "description": "This is a package to make a rest api client c-sharp file from openapi's json and yaml",
   "author": "Re:Beat",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -9,12 +9,6 @@
       },
       "hash": "38fecf55e4fd94ccfe58a92ed8ad1a529ba1694e"
     },
-    "com.rebeat.openapicodegen": {
-      "version": "file:OpenApiCodeGen",
-      "depth": 0,
-      "source": "embedded",
-      "dependencies": {}
-    },
     "com.unity.burst": {
       "version": "1.8.26",
       "depth": 2,
@@ -198,6 +192,12 @@
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
+    },
+    "jp.rebeat.openapicodegen": {
+      "version": "file:OpenApiCodeGen",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {}
     },
     "com.unity.modules.accessibility": {
       "version": "1.0.0",


### PR DESCRIPTION
This pull request updates the OpenApiCodeGen Unity package to use the new package name `jp.rebeat.openapicodegen` instead of `com.rebeat.openapicodegen`, and bumps the version to 0.3.1. It also cleans up legacy meta files and updates package references. The most important changes are:

**Package Renaming and Versioning:**
* Changed the package name throughout the project from `com.rebeat.openapicodegen` to `jp.rebeat.openapicodegen` in all relevant `.uxml` files, `package.json`, and package lock files to ensure consistency and correct referencing. [[1]](diffhunk://#diff-84fb5dd9f4ac875dcd329378a86f8d819d78292e221aeb82fe3d033d45ee9d39L2-R2) [[2]](diffhunk://#diff-0a26cde70b9363e5b3d04043110ec028e54f3d76e4186b1aa56f81ede0b08864L2-R2) [[3]](diffhunk://#diff-2d9b9a79e3a313778097ce0b27c1eb1d5c2eb9e184d30dffe01dc0777750ec2bL2-R2) [[4]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL12-L17) [[5]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aR196-R201)
* Updated the package version in `package.json` from `0.3.0` to `0.3.1` to reflect the changes.
* Added a changelog entry for version 0.3.1 describing the package name fix.

**Cleanup:**
* Removed the obsolete `Assets/Scripts.meta` file, likely as part of project cleanup.

**Package Reference Updates:**
* Updated `Packages/packages-lock.json` to remove the old package reference and add the new one, matching the new naming convention. [[1]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL12-L17) [[2]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aR196-R201)