### PR TITLE
fix: change package name and namespace from ReBeat to Rhycol

### DIFF
--- a/Packages/OpenApiCodeGen/CHANGELOG.md
+++ b/Packages/OpenApiCodeGen/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## unreleased
 
+### Fixed
+
+- change package name
+- change namespace Begining by "Rhycol"
+
 ## [0.3.1]
 
 ### Fixed

--- a/Packages/OpenApiCodeGen/Editor/ApplicationConfig.cs
+++ b/Packages/OpenApiCodeGen/Editor/ApplicationConfig.cs
@@ -1,7 +1,7 @@
-﻿using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.Lib;
+﻿using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Lib;
 
-namespace ReBeat.OpenApiCodeGen
+namespace Rhycol.OpenApiCodeGen
 {
     internal static class ApplicationConfig
     {

--- a/Packages/OpenApiCodeGen/Editor/ApplicationConstant.cs
+++ b/Packages/OpenApiCodeGen/Editor/ApplicationConstant.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.IO;
 
-namespace ReBeat.OpenApiCodeGen
+namespace Rhycol.OpenApiCodeGen
 {
     internal static class ApplicationConstant
     {
         public static readonly string CacheFolderPath = Path.Combine(
             Path.GetTempPath(),
-            "ReBeat",
+            "Rhycol",
             "OpenApiCodeGen"
         );
         public static readonly string PROJECT_FOLDER_PATH = Path.Combine(
@@ -21,7 +21,7 @@ namespace ReBeat.OpenApiCodeGen
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             "AppData",
             "LocalLow",
-            "ReBeat",
+            "Rhycol",
             "OpenApiCodeGen"
         );
 #elif UNITY_EDITOR_OSX
@@ -29,14 +29,14 @@ namespace ReBeat.OpenApiCodeGen
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             "Library",
             "Application Support",
-            "ReBeat",
+            "Rhycol",
             "OpenApiCodeGen"
         );
 #elif UNITY_EDITOR_LINUX
         public static readonly string USER_FOLDER_PATH = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".config",
-                "ReBeat",
+                "Rhycol",
                 "OpenApiCodeGen"
             );
 #else

--- a/Packages/OpenApiCodeGen/Editor/Domain/ExitStatus.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/ExitStatus.cs
@@ -1,4 +1,4 @@
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     public enum ExitStatus
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/ProcessResponse.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/ProcessResponse.cs
@@ -1,6 +1,6 @@
 #nullable enable
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     public class ProcessResponse
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/Progress/FailedProgressStatus.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Progress/FailedProgressStatus.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class FailedProgressStatus : IProgressStatus
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/Progress/IProgressStatus.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Progress/IProgressStatus.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal interface IProgressStatus
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/Progress/PendingProgressStatus.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Progress/PendingProgressStatus.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class PendingProgressStatus : IProgressStatus
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/Progress/SucceedProgressStatus.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Progress/SucceedProgressStatus.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class SucceedProgressStatus : IProgressStatus
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/Repositories/IAsyncRepository.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Repositories/IAsyncRepository.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 using System.Threading.Tasks;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     public interface IAsyncRepository<T> where T : class
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/Setting/GenerationCSharpSetting.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Setting/GenerationCSharpSetting.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class GenerationCSharpSetting
     {
@@ -22,7 +22,7 @@ namespace ReBeat.OpenApiCodeGen.Core
         public bool OptionalMethodArgument { get; set; } = true;
         public bool OptionalAssemblyInfo { get; set; } = true;
         public bool OptionalProjectFile { get; set; } = false;
-        public string PackageName { get; set; } = "ReBeat.OpenApiCodeGen";
+        public string PackageName { get; set; } = "Rhycol.OpenApiCodeGen";
         public bool ReturnICollection { get; set; } = false;
         /// <summary>
         /// The target .NET framework version. To target multiple frameworks, use ; as the separator, 

--- a/Packages/OpenApiCodeGen/Editor/Domain/Setting/ProjectSetting.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Setting/ProjectSetting.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class ProjectSetting
     {

--- a/Packages/OpenApiCodeGen/Editor/Domain/Setting/UserSetting.cs
+++ b/Packages/OpenApiCodeGen/Editor/Domain/Setting/UserSetting.cs
@@ -1,4 +1,4 @@
-﻿namespace ReBeat.OpenApiCodeGen.Core
+﻿namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class UserSetting
     {

--- a/Packages/OpenApiCodeGen/Editor/Service/Dto/CheckDockerInstalledDto.cs
+++ b/Packages/OpenApiCodeGen/Editor/Service/Dto/CheckDockerInstalledDto.cs
@@ -1,4 +1,4 @@
-﻿namespace ReBeat.OpenApiCodeGen.Core
+﻿namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class CheckDockerInstalledDto
     {

--- a/Packages/OpenApiCodeGen/Editor/Service/Dto/GenerateApiClientDto.cs
+++ b/Packages/OpenApiCodeGen/Editor/Service/Dto/GenerateApiClientDto.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class GenerateApiClientDto
     {

--- a/Packages/OpenApiCodeGen/Editor/Service/Dto/SetupDto.cs
+++ b/Packages/OpenApiCodeGen/Editor/Service/Dto/SetupDto.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class SetupDto
     {

--- a/Packages/OpenApiCodeGen/Editor/Service/GenerationService.cs
+++ b/Packages/OpenApiCodeGen/Editor/Service/GenerationService.cs
@@ -5,10 +5,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Lib;
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.Lib;
+using Rhycol.OpenApiCodeGen.UI;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class GenerationService
     {

--- a/Packages/OpenApiCodeGen/Editor/Service/SettingService.cs
+++ b/Packages/OpenApiCodeGen/Editor/Service/SettingService.cs
@@ -2,10 +2,10 @@
 using System;
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.UI;
 
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class SettingService
     {

--- a/Packages/OpenApiCodeGen/Editor/Service/SetupService.cs
+++ b/Packages/OpenApiCodeGen/Editor/Service/SetupService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class SetupService
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Exception/ApplicationServiceException.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Exception/ApplicationServiceException.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     public class ApplicationServiceException : Exception
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Exception/DomainException.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Exception/DomainException.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class DomainException : Exception
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Exception/ExternalServiceException.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Exception/ExternalServiceException.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class ExternalServiceException : Exception
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Exception/ExternalStorageException.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Exception/ExternalStorageException.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     internal class ExternalStorageException : Exception
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/GenerateProvider.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/GenerateProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace ReBeat.OpenApiCodeGen.Core
+﻿namespace Rhycol.OpenApiCodeGen.Core
 {
     internal enum GenerateProvider
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Interfaces/IGenerator.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Interfaces/IGenerator.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     interface IGenerator
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Lib/JsonFileStore.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Lib/JsonFileStore.cs
@@ -5,11 +5,11 @@ using System.IO;
 using System.Threading.Tasks;
 
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
 using UnityEngine;
 
-namespace ReBeat.OpenApiCodeGen.Lib
+namespace Rhycol.OpenApiCodeGen.Lib
 {
     public class JsonFileStore<T> where T : class
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiCodeGenerator.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiCodeGenerator.cs
@@ -6,11 +6,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
 using UnityEngine;
 
-namespace ReBeat.OpenApiCodeGen.Lib
+namespace Rhycol.OpenApiCodeGen.Lib
 {
     internal class OpenApiCodeGenerator : IGenerator
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiCsharpOption.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiCsharpOption.cs
@@ -1,9 +1,9 @@
 ﻿#nullable enable
 
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
-namespace ReBeat.OpenApiCodeGen.Lib
+namespace Rhycol.OpenApiCodeGen.Lib
 {
     internal class OpenApiCsharpOption
     {
@@ -26,7 +26,7 @@ namespace ReBeat.OpenApiCodeGen.Lib
         public bool optionalMethodArgument = true;
         public bool optionalAssemblyInfo = true;
         public bool optionalProjectFile = false;
-        public string packageName = "ReBeat.OpenApiCodeGen";
+        public string packageName = "Rhycol.OpenApiCodeGen";
         public bool returnICollection = false;
         /// <summary>
         /// The target .NET framework version. To target multiple frameworks, use ; as the separator, 

--- a/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiDependenceLibrary.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiDependenceLibrary.cs
@@ -1,6 +1,6 @@
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     public enum OpenApiDependenceLibrary
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiTargetFramework.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Lib/OpenApi/OpenApiTargetFramework.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     [Flags]
     public enum OpenApiTargetFramework

--- a/Packages/OpenApiCodeGen/Editor/Share/Process/DockerProcess.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Process/DockerProcess.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ReBeat.OpenApiCodeGen.Core
+namespace Rhycol.OpenApiCodeGen.Core
 {
     public class DockerProcess
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Repository/GenerationCSharpSettingJsonRepository.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Repository/GenerationCSharpSettingJsonRepository.cs
@@ -4,10 +4,10 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
 
-namespace ReBeat.OpenApiCodeGen.Lib
+namespace Rhycol.OpenApiCodeGen.Lib
 {
     internal class GenerationCSharpSettingJsonRepository : IAsyncRepository<GenerationCSharpSetting>
     {
@@ -64,7 +64,7 @@ namespace ReBeat.OpenApiCodeGen.Lib
             public bool OptionalMethodArgument = true;
             public bool OptionalAssemblyInfo = true;
             public bool OptionalProjectFile = false;
-            public string PackageName = "ReBeat.OpenApiCodeGen";
+            public string PackageName = "Rhycol.OpenApiCodeGen";
             public bool ReturnICollection = false;
             public string TargetFramework = "netstandard2.1";
             public bool UseCollection = false;

--- a/Packages/OpenApiCodeGen/Editor/Share/Repository/ProjectSettingJsonRepository.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Repository/ProjectSettingJsonRepository.cs
@@ -4,10 +4,10 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
 
-namespace ReBeat.OpenApiCodeGen.Lib
+namespace Rhycol.OpenApiCodeGen.Lib
 {
     internal class ProjectSettingJsonRepository : IAsyncRepository<ProjectSetting>
     {

--- a/Packages/OpenApiCodeGen/Editor/Share/Repository/UserSettingJsonRepository.cs
+++ b/Packages/OpenApiCodeGen/Editor/Share/Repository/UserSettingJsonRepository.cs
@@ -4,10 +4,10 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
 
-namespace ReBeat.OpenApiCodeGen.Lib
+namespace Rhycol.OpenApiCodeGen.Lib
 {
     internal class UserSettingJsonRepository : IAsyncRepository<UserSetting>
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/Presenter/GenerationPresenter.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/Presenter/GenerationPresenter.cs
@@ -3,11 +3,11 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.UI;
 
 
-namespace ReBeat.OpenApiCodeGen.Presenter
+namespace Rhycol.OpenApiCodeGen.Presenter
 {
     internal class MenuPresenter : IGenerationPresenter
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/Presenter/IGenerationPresenter.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/Presenter/IGenerationPresenter.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.UI;
 
-namespace ReBeat.OpenApiCodeGen.Presenter
+namespace Rhycol.OpenApiCodeGen.Presenter
 {
     interface IGenerationPresenter
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/IGenerationMenu.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/IGenerationMenu.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 using System;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal interface IGenerationView
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/MenuWindow.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/MenuWindow.cs
@@ -2,15 +2,15 @@
 
 using System;
 
-using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.Presenter;
+using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Presenter;
 
 using UnityEditor;
 
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class MenuWindow : EditorWindow, IGenerationView
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/MenuWindow.uxml
+++ b/Packages/OpenApiCodeGen/Editor/UI/GenerateMenu/View/MenuWindow.uxml
@@ -1,5 +1,5 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Packages/jp.rebeat.openapicodegen/Editor/UI/MainMenu/MenuWindow.uss?fileID=7433441132597879392&amp;guid=388ca6004f36749a6b4b09cb6c501c03&amp;type=3#MenuWindow" />
+    <Style src="project://database/Packages/jp.rhycol.openapicodegen/Editor/UI/MainMenu/MenuWindow.uss?fileID=7433441132597879392&amp;guid=388ca6004f36749a6b4b09cb6c501c03&amp;type=3#MenuWindow" />
     <ui:ScrollView>
         <ui:Label tabindex="-1" text="OpenAPI Code Generator" display-tooltip-when-elided="true" name="Title" style="-unity-font-style: bold; font-size: 28px;" />
         <ui:TextField picking-mode="Ignore" label="document file path/url" name="DocumentFilePath" binding-path="m_DocumentFilePath" style="white-space: nowrap; text-overflow: ellipsis;" />

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Dto/GenerationCSharpSetting.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Dto/GenerationCSharpSetting.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class GenerationCSharpSettingDisplayDto
     {
@@ -23,7 +23,7 @@ namespace ReBeat.OpenApiCodeGen.UI
         public bool OptionalMethodArgument { get; set; } = true;
         public bool OptionalAssemblyInfo { get; set; } = true;
         public bool OptionalProjectFile { get; set; } = false;
-        public string PackageName { get; set; } = "ReBeat.OpenApiCodeGen";
+        public string PackageName { get; set; } = "Rhycol.OpenApiCodeGen";
         public bool ReturnICollection { get; set; } = false;
         /// <summary>
         /// The target .NET framework version. To target multiple frameworks, use ; as the separator, 

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Dto/ProjectSettingDisplayDto.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Dto/ProjectSettingDisplayDto.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class ProjectSettingDisplayDto
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Dto/UserSettingDisplayDto.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Dto/UserSettingDisplayDto.cs
@@ -1,4 +1,4 @@
-﻿namespace ReBeat.OpenApiCodeGen.UI
+﻿namespace Rhycol.OpenApiCodeGen.UI
 {
     internal class UserSettingDisplayDto
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Presenter/ISettingPresenter.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Presenter/ISettingPresenter.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.UI;
 
-namespace ReBeat.OpenApiCodeGen.Presenter
+namespace Rhycol.OpenApiCodeGen.Presenter
 {
     internal interface ISettingPresenter
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Presenter/SettingPresenter.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/Presenter/SettingPresenter.cs
@@ -2,10 +2,10 @@
 
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.UI;
 
-namespace ReBeat.OpenApiCodeGen.Presenter
+namespace Rhycol.OpenApiCodeGen.Presenter
 {
     class SettingPresenter : ISettingPresenter
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/ISettingView.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/ISettingView.cs
@@ -1,9 +1,9 @@
 ﻿#nullable enable
 using System;
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal interface ISettingView
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/SettingMenu.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/SettingMenu.cs
@@ -1,9 +1,9 @@
 ﻿#nullable enable
 using System;
 
-using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.Presenter;
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Presenter;
+using Rhycol.OpenApiCodeGen.UI;
 
 using UnityEditor;
 

--- a/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/SettingMenu.uxml
+++ b/Packages/OpenApiCodeGen/Editor/UI/SettingMenu/View/SettingMenu.uxml
@@ -1,12 +1,12 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Packages/jp.rebeat.openapicodegen/Editor/UI/SettingMenu/SettingMenu.uss?fileID=7433441132597879392&amp;guid=85d61e68e42234629a04d6023ac5024b&amp;type=3#SettingMenu" />
+    <Style src="project://database/Packages/jp.rhycol.openapicodegen/Editor/UI/SettingMenu/SettingMenu.uss?fileID=7433441132597879392&amp;guid=85d61e68e42234629a04d6023ac5024b&amp;type=3#SettingMenu" />
     <ui:ScrollView class="setting-menu-scroll">
         <ui:Label tabindex="-1" text="Setting Menu" display-tooltip-when-elided="true" style="font-size: 30px; -unity-font-style: bold;" />
         <ui:Foldout text="User Settings" name="UserSettingsFoldout" class="setting-section" style="font-size: 14px;">
             <ui:TextField picking-mode="Ignore" label="Docker Path" name="DockerPathField" />
         </ui:Foldout>
         <ui:Foldout text="Project Settings" name="ProjectSettingsFoldout" class="setting-section" style="font-size: 14px;">
-            <ui:EnumField label="Generate Provider" type="ReBeat.OpenApiCodeGen.Core.GenerateProvider, Unity.OpenApiCodeGen.Editor" name="GenerateProviderField" />
+            <ui:EnumField label="Generate Provider" type="Rhycol.OpenApiCodeGen.Core.GenerateProvider, Unity.OpenApiCodeGen.Editor" name="GenerateProviderField" />
             <ui:TextField picking-mode="Ignore" label="Default API Document File URL" name="DefaultApiDocumentFilePathOrUrlField" />
             <ui:TextField picking-mode="Ignore" label="Default Output Folder Path" name="DefaultOutputFolderPathField" />
         </ui:Foldout>
@@ -19,7 +19,7 @@
             <ui:Toggle label="Equatable" name="EquatableField" style="display: flex; visibility: visible; justify-content: flex-start;" />
             <ui:Toggle label="Hide Generation Timestamp" name="HideGenerationTimestampField" />
             <ui:TextField picking-mode="Ignore" label="Interface Prefix" name="InterfacePrefixField" />
-            <ui:EnumField label="Library" type="ReBeat.OpenApiCodeGen.UI.OpenApiDependenceLibrary, Unity.OpenApiCodeGen.Editor" name="LibraryField" />
+            <ui:EnumField label="Library" type="Rhycol.OpenApiCodeGen.UI.OpenApiDependenceLibrary, Unity.OpenApiCodeGen.Editor" name="LibraryField" />
             <ui:TextField picking-mode="Ignore" label="License ID" name="LicenseIdField" />
             <ui:TextField picking-mode="Ignore" label="Model Property Naming" name="ModelPropertyNamingField" />
             <ui:Toggle label=".Net Core Project File" name="NetCoreProjectFileField" />

--- a/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/Presenter/ISetupPresenter.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/Presenter/ISetupPresenter.cs
@@ -2,10 +2,10 @@
 
 using System;
 
-using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.UI;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     interface ISetupPresenter
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/Presenter/SetupPresenter.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/Presenter/SetupPresenter.cs
@@ -2,10 +2,10 @@
 
 using System.Threading.Tasks;
 
-using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.UI;
 
-namespace ReBeat.OpenApiCodeGen.Presenter
+namespace Rhycol.OpenApiCodeGen.Presenter
 {
     internal class SetupPresenter : ISetupPresenter
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/ISetupView.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/ISetupView.cs
@@ -2,9 +2,9 @@
 
 using System;
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
-namespace ReBeat.OpenApiCodeGen.UI
+namespace Rhycol.OpenApiCodeGen.UI
 {
     internal interface ISetupView
     {

--- a/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/SetupMenu.cs
+++ b/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/SetupMenu.cs
@@ -2,9 +2,9 @@
 
 using System;
 
-using ReBeat.OpenApiCodeGen.Core;
-using ReBeat.OpenApiCodeGen.Presenter;
-using ReBeat.OpenApiCodeGen.UI;
+using Rhycol.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Presenter;
+using Rhycol.OpenApiCodeGen.UI;
 
 using UnityEditor;
 

--- a/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/SetupMenu.uxml
+++ b/Packages/OpenApiCodeGen/Editor/UI/SetupMenu/View/SetupMenu.uxml
@@ -1,9 +1,9 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Packages/jp.rebeat.openapicodegen/Editor/UI/SetupMenu/SetupMenu.uss?fileID=7433441132597879392&amp;guid=95ad4dafff53c44029241f28a46bf7b4&amp;type=3#SetupMenu" />
+    <Style src="project://database/Packages/jp.rhycol.openapicodegen/Editor/UI/SetupMenu/SetupMenu.uss?fileID=7433441132597879392&amp;guid=95ad4dafff53c44029241f28a46bf7b4&amp;type=3#SetupMenu" />
     <ui:Label text="Setup OpenAPI Code Generator" style="-unity-font-style: bold; font-size: 30px;" />
     <ui:GroupBox name="SetupGroup" style="margin-top: 24px;">
         <ui:Label tabindex="-1" text="1. Choose Generate Provider" display-tooltip-when-elided="true" style="-unity-font-style: bold; font-size: 16px; margin-bottom: 16px;" />
-        <ui:EnumField label="Provider" type="ReBeat.OpenApiCodeGen.Core.GenerateProvider, Unity.OpenApiCodeGen.Editor" name="ProviderField" />
+        <ui:EnumField label="Provider" type="Rhycol.OpenApiCodeGen.Core.GenerateProvider, Unity.OpenApiCodeGen.Editor" name="ProviderField" />
         <ui:Label tabindex="-1" text="2. Input Docker application full path" display-tooltip-when-elided="true" style="-unity-font-style: bold; font-size: 16px; margin-bottom: 16px;" />
         <ui:TextField picking-mode="Ignore" label="Docker fullpath" auto-correction="false" name="DockerPathField" />
         <ui:Button text="click to check path" display-tooltip-when-elided="true" name="CheckRunnableDockerButton" focusable="true" />

--- a/Packages/OpenApiCodeGen/Test/Core/Process.Test.cs
+++ b/Packages/OpenApiCodeGen/Test/Core/Process.Test.cs
@@ -4,7 +4,7 @@
 
 using NUnit.Framework;
 
-using ReBeat.OpenApiCodeGen.Core;
+using Rhycol.OpenApiCodeGen.Core;
 
 using UnityEngine;
 

--- a/Packages/OpenApiCodeGen/package.json
+++ b/Packages/OpenApiCodeGen/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jp.rebeat.openapicodegen",
+  "name": "jp.rhycol.openapicodegen",
   "version": "0.3.1",
   "displayName": "OpenApiCodeGen",
   "description": "This is a package to make a rest api client c-sharp file from openapi's json and yaml",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -193,7 +193,7 @@
       },
       "url": "https://packages.unity.com"
     },
-    "jp.rebeat.openapicodegen": {
+    "jp.rhycol.openapicodegen": {
       "version": "file:OpenApiCodeGen",
       "depth": 0,
       "source": "embedded",


### PR DESCRIPTION
## What to do
- Updated package name in package.json and packages-lock.json
- Changed namespace references throughout the codebase from ReBeat.OpenApiCodeGen to Rhycol.OpenApiCodeGen
- Adjusted cache folder paths and project settings to reflect the new namespace
- Updated related UI elements and settings to ensure consistency with the new naming

## Supplement
it changes package name in package.json. this is intentionally change, so it need to fix openUPM's package settings later.