### PR TITLE
chore: update version to 0.4.0 and add changelog entry

### DIFF
--- a/Packages/OpenApiCodeGen/CHANGELOG.md
+++ b/Packages/OpenApiCodeGen/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## unreleased
 
+## [0.4.0]
+
 ### Fixed
 
 - change package name

--- a/Packages/OpenApiCodeGen/package.json
+++ b/Packages/OpenApiCodeGen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp.rhycol.openapicodegen",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "displayName": "OpenApiCodeGen",
   "description": "This is a package to make a rest api client c-sharp file from openapi's json and yaml",
   "author": "Re:Beat",


### PR DESCRIPTION
This pull request updates the `OpenApiCodeGen` package to version 0.4.0, reflecting a recent fix to the package name.

Versioning and changelog updates:

* Updated the version in `package.json` from 0.3.1 to 0.4.0 to reflect the new release.
* Added a new 0.4.0 section to the `CHANGELOG.md` to document the version bump and associated fixes.